### PR TITLE
Use MVT-Postgresql provider for all non-point collections

### DIFF
--- a/pygeoapi-skin-dashboard/templates/collections/items/index.html
+++ b/pygeoapi-skin-dashboard/templates/collections/items/index.html
@@ -46,7 +46,8 @@
         <div class="card border-left-info shadow py-2 mb-3">
           <div class="card-body">
             <div class="row">
-              <div id="limit" class="col-sm-12">
+              <div id="limit" class="col-sm-12 d-flex justify-content-between align-items-center">
+                <span>
                 Limit:
                 <select id="limits">
                   <option value="{{ config['server']['limit'] }}">{{ config['server']['limit'] }} ({% trans %}default{% endtrans %})</option>
@@ -54,6 +55,10 @@
                   <option value="1000">1,000</option>
                   <option value="2000">2,000</option>
                 </select>
+                </span>
+                {% if data['numberMatched'] %}
+                <span id="item-count">{% trans %}Items in this collection{% endtrans %}: {{ data['numberMatched'] }}</span>
+                {% endif %}
                 <script>
                   var select = document.getElementById('limits');
                   let params = (new URL(document.location)).searchParams;

--- a/pygeoapi-skin-dashboard/templates/collections/tiles/index.html
+++ b/pygeoapi-skin-dashboard/templates/collections/tiles/index.html
@@ -43,6 +43,18 @@
         outline: 2px solid #55677F;
         outline-offset: 2px;
     }
+
+    select.metadata-link {
+        appearance: none;
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        background-image: url('data:image/svg+xml;charset=US-ASCII,<svg fill="white" height="10" width="10" xmlns="http://www.w3.org/2000/svg"><polygon points="0,0 10,0 5,5"/></svg>');
+        background-repeat: no-repeat;
+        background-position: right 12px bottom 12px;
+        background-size: 12px;
+        border: none; 
+        padding-right: 32px;
+    }
     </style>
 {%- endblock %}
 
@@ -50,27 +62,72 @@
     <section id="collection">
       <h1>{{ data['title'] }}</h1>
       <div class="row">
-        <div class="col-md-10">
+        <div class="col-md-9">
           <div id="items-map"></div>
         </div>
-        <div class="col-md-1">
-            <a id="metadata_link" class="metadata-link" href="{{ config['server']['url'] }}/collections/{{ data['id'] }}/tiles/{{ data['tilesets'][0] }}/metadata" target="_blank">{% trans %}Metadata{% endtrans %}</a>
-          </div>
+        <div class="col-md-2">
+
+        <select class="metadata-link" id="tilingScheme">
+            {% for tileset in data['tilesets'] %}
+            <option value="{{ tileset }}">{{ tileset }}</option>
+            {% endfor %}
+        </select>
+
+        <a id="metadata_link" class="metadata-link" href="{{ config['server']['url'] }}/collections/{{ data['id'] }}/tiles/{{ data['tilesets'][0] }}/metadata" target="_blank">{% trans %}Metadata{% endtrans %}</a>
+        </div>
       </div>
     </section>
 {%- endblock %}
 
 {%- block extrafoot %}
     <script>
-    var scheme = "{{ data['tilesets'][0] }}";
-    var map = L.map('items-map').setView([{{ 45 }}, {{ -75 }}], 10);
-
-    map.addLayer(new L.TileLayer(
-        '{{ config["server"]["map"]["url"] }}', {
-            maxZoom: {{ data['maxzoom'] }},
-            attribution: '{{ config["server"]["map"]["attribution"] | safe }}'
+        var select = document.getElementById('tilingScheme');
+        let params = (new URL(document.location)).searchParams;
+        var scheme = params.get('scheme') ?? select.value;
+        if (scheme) {
+            select.value = scheme;
+            document.getElementById("metadata_link").href = "{{ config['server']['url'] }}/collections/{{ data['id'] }}/tiles/" + scheme + "/metadata";
         }
-    ));
+        select.addEventListener('change', ev => {
+          var scheme = ev.target.value;
+          console.log(scheme);
+          document.location.search = `scheme=${scheme}`;
+          document.getElementById("metadata_link").href = "{{ config['server']['url'] }}/collections/{{ data['id'] }}/tiles/" + scheme + "/metadata";
+        });
+    </script>
+    <script>
+        
+    if (scheme !== "WorldCRS84Quad"){
+        var map = L.map('items-map').setView([{{ 45 }}, {{ -75 }}], 10);
+
+        map.addLayer(new L.TileLayer(
+            '{{ config["server"]["map"]["url"] }}', {
+                maxZoom: {{ data['maxzoom'] }},
+                attribution: '{{ config["server"]["map"]["attribution"] | safe }}'
+            }
+        ));
+
+    } else {
+
+        var map = L.map('items-map',{
+            crs: L.CRS.EPSG4326
+        }).setView([{{ 45 }}, {{ -75 }}], 10);
+
+        map.addLayer(new L.TileLayer(
+            '{{ config["server"]["map"]["url"] }}', {
+                maxZoom: {{ data['maxzoom'] }},
+                attribution: '{{ config["server"]["map"]["attribution"] | safe }}',
+                tileSize: L.point(512, 256)
+            }
+        ));
+        document.getElementById('items-map').insertAdjacentHTML(
+            'afterend', 
+            '<div style="margin-top: 1rem; text-align: center;">' +
+            '{% trans %}Warning: Basemap may be in a different projection{% endtrans %}' +
+            '</div>'
+        );
+
+    }
 
     {% for link in data["links"] %}
       {% if link["rel"] == "item" %}
@@ -105,6 +162,13 @@
             },
             vectorTileLayerStyles: {
                 {{ data["id"] }}: function(properties, zoom) {
+                    return {
+                        color: '#1B335F',
+                        fillColor: '#1B335F',
+                        weight: 0.25 + (zoom / 4),
+                    }
+                },
+                'ref_{{ data["id"] }}': function(properties, zoom) {
                     return {
                         color: '#1B335F',
                         fillColor: '#1B335F',

--- a/pygeoapi.config.yml
+++ b/pygeoapi.config.yml
@@ -29,7 +29,7 @@
 #
 # =================================================================
 
-data_link: &data-link
+data_link: &data_link
   type: text/html
   rel: canonical
   title: data source
@@ -150,7 +150,7 @@ resources:
             "@id": schema:subjectOf
             "@type": "@id"
     links:
-      - <<: *data-link
+      - <<: *data_link
         href: https://www.usgs.gov/core-science-systems/ngp/national-hydrography/access-national-hydrography-products
     extents: &extents
       spatial:
@@ -176,7 +176,7 @@ resources:
     templates: 
       path: /skin-dashboard/templates/jsonld/hu04
     links:
-      - <<: *data-link
+      - <<: *data_link
         href: https://www.usgs.gov/core-science-systems/ngp/national-hydrography/access-national-hydrography-products
     extents: *extents
     providers:
@@ -196,7 +196,7 @@ resources:
     templates: 
       path: /skin-dashboard/templates/jsonld/hu06
     links:
-      - <<: *data-link
+      - <<: *data_link
         href: https://www.usgs.gov/core-science-systems/ngp/national-hydrography/access-national-hydrography-products
     extents: *extents
     providers:
@@ -215,7 +215,7 @@ resources:
       - USGS
     templates: /skin-dashboard/templates/jsonld/hu08
     links:
-      - <<: *data-link
+      - <<: *data_link
         href: https://www.usgs.gov/core-science-systems/ngp/national-hydrography/access-national-hydrography-products
     extents: *extents
     providers:
@@ -236,7 +236,7 @@ resources:
       - USGS
     templates: /skin-dashboard/templates/jsonld/hu10
     links:
-      - <<: *data-link
+      - <<: *data_link
         href: https://www.usgs.gov/core-science-systems/ngp/national-hydrography/access-national-hydrography-products
     extents: *extents
     providers:
@@ -264,9 +264,9 @@ resources:
             "@id": schema:sameAs
             "@type": "@id"
     links:
-      - <<: *data-link
+      - <<: *data_link
         href: https://cida.usgs.gov/ngwmn/
-      - <<: *data-link
+      - <<: *data_link
         title: code list with links
         href: https://water.usgs.gov/ogw/NatlAqCode-reflist.html
     extents:
@@ -297,7 +297,7 @@ resources:
             "@id": schema:sameAs
             "@type": "@id"
     links:
-      - <<: *data-link
+      - <<: *data_link
         href: https://water.usgs.gov/GIS/metadata/usgswrd/XML/aquifers_us.xml
     extents:
       spatial:
@@ -324,10 +324,10 @@ resources:
         - schema: https://schema.org/
           shr: schema:name
     links:
-      - <<: *data-link
+      - <<: *data_link
         href: https://doi.org/10.5066/F7F76BSS
         hreflang: en-US
-      - <<: *data-link
+      - <<: *data_link
         title: report documenting data
         href: https://doi.org/10.1111/gwat.12806
     extents:
@@ -352,7 +352,7 @@ resources:
       - USGS
     templates: /skin-dashboard/templates/jsonld/gages
     links:
-      - <<: *data-link
+      - <<: *data_link
         href: https://github.com/internetofwater/ref_gages
     extents: *extents
     providers:
@@ -373,7 +373,7 @@ resources:
         - schema: https://schema.org/
           name_at_outlet: schema:name
     links:
-      - <<: *data-link
+      - <<: *data_link
         href: https://github.com/internetofwater/ref_rivers
     extents: *extents
     providers:
@@ -444,7 +444,7 @@ resources:
             "@id": schema:subjectOf
             "@type": schema:url
     links:
-      - <<: *data-link
+      - <<: *data_link
         href: https://github.com/internetofwater/ref_dams
     extents: *extents
     providers:
@@ -480,10 +480,10 @@ resources:
             "@id": schema:geoIntersects
             "@type": "@id"
     links:
-      - <<: *data-link
+      - <<: *data_link
         title: EPA PWSID List source
         href: https://echo.epa.gov/tools/data-downloads/sdwa-download-summary
-      - <<: *data-link
+      - <<: *data_link
         title: geographic data source
         href: https://github.com/cgs-earth/ref_pws
     extents: *extents
@@ -510,10 +510,10 @@ resources:
             "@id": schema:subjectOf
             "@type": "@id"
     links:
-      - <<: *data-link
+      - <<: *data_link
         title: geographic data source
         href: https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html
-      - <<: *data-link
+      - <<: *data_link
         title: Census data source
         href: https://data.census.gov/cedsci
     extents: *extents
@@ -538,10 +538,10 @@ resources:
             "@id": schema:subjectOf
             "@type": "@id"
     links:
-      - <<: *data-link
+      - <<: *data_link
         title: geographic data source
         href: https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html
-      - <<: *data-link
+      - <<: *data_link
         title: Census data source
         href: https://data.census.gov/cedsci
     extents: *extents
@@ -565,7 +565,7 @@ resources:
       context:
         - name: https://schema.org/name
     links:
-      - <<: *data-link
+      - <<: *data_link
         title: geographic data source
         href: https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html
     extents: *extents
@@ -587,7 +587,7 @@ resources:
       context:
         - name: https://schema.org/name
     links:
-      - <<: *data-link
+      - <<: *data_link
         title: geographic data source
         href: https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html
     extents: *extents
@@ -607,10 +607,10 @@ resources:
       context:
         - name10: https://schema.org/name
     links:
-      - <<: *data-link
+      - <<: *data_link
         title: geographic data source
         href: https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html
-      - <<: *data-link
+      - <<: *data_link
         title: descriptive data source
         href: https://www.census.gov/programs-surveys/geography/guidance/geo-areas/urban-rural/2010-urban-rural.html
     extents: *extents
@@ -635,10 +635,10 @@ resources:
             "@id": schema:subjectOf
             "@type": "@id"
     links:
-      - <<: *data-link
+      - <<: *data_link
         title: geographic data source
         href: https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html
-      - <<: *data-link
+      - <<: *data_link
         title: Census data source
         href: https://data.census.gov/cedsci
     extents: *extents
@@ -660,10 +660,10 @@ resources:
   #     - Sitemap
   #     - Internet of Water
   #   links:
-  #     - <<: *data-link
+  #     - <<: *data_link
   #       title: information
   #       href: https://geoconnex.us
-  #     - <<: *data-link
+  #     - <<: *data_link
   #       title: sitemap
   #       href: https://geoconnex.us/sitemap.xml
   #   extents:

--- a/pygeoapi.config.yml
+++ b/pygeoapi.config.yml
@@ -74,12 +74,14 @@ huc_sparql_query: &huc_sparql_query
     - 'BIND(REPLACE(STR(?containedCatchment), "^.*ref/(hu[0-9]+)/.*$", "$1") AS ?hucLevel)'
 
 tile_defaults: &tile_defaults
+  <<: *provider_defaults
   type: tile
-  name: MVT-tippecanoe
+  name: MVT-postgresql
+  storage_crs: http://www.opengis.net/def/crs/EPSG/0/4326
   options:
     zoom:
-      min: 0
-      max: 10
+      min: 1
+      max: 16
   format:
     name: pbf
     mimetype: application/vnd.mapbox-vector-tile
@@ -165,7 +167,8 @@ resources:
         table: hu02
         sparql_query: *huc_sparql_query
       - <<: *tile_defaults
-        data: ${TILES_PATH}/hu02/${TILES_SUFFIX:-}
+        id_field: huc2
+        table: hu02
   hu04:
     type: collection
     title: HU04
@@ -185,7 +188,8 @@ resources:
         table: hu04
         sparql_query: *huc_sparql_query
       - <<: *tile_defaults
-        data: ${TILES_PATH}/hu04/${TILES_SUFFIX:-}
+        id_field: huc4
+        table: hu04
   hu06:
     type: collection
     title: HU06
@@ -205,7 +209,8 @@ resources:
         table: hu06
         sparql_query: *huc_sparql_query
       - <<: *tile_defaults
-        data: ${TILES_PATH}/hu06/${TILES_SUFFIX:-}
+        id_field: huc6
+        table: hu06
   hu08:
     type: collection
     title: HU08
@@ -226,7 +231,8 @@ resources:
           <<: *huc_sparql_query
           select: '?huc (GROUP_CONCAT(?containedCatchment; SEPARATOR="|") AS ?hucs)'
       - <<: *tile_defaults
-        data: ${TILES_PATH}/hu08/${TILES_SUFFIX:-}
+        id_field: huc8
+        table: hu08
   hu10:
     type: collection
     title: HU10
@@ -245,7 +251,8 @@ resources:
         id_field: huc10
         table: hu10
       - <<: *tile_defaults
-        data: ${TILES_PATH}/hu10/${TILES_SUFFIX:-}
+        id_field: huc10
+        table: hu10
   nat_aq:
     type: collection
     title: USGS National Aquifers
@@ -282,6 +289,9 @@ resources:
         id_field: nat_aqfr_cd
         title_field: aq_name
         table: nat_aq
+      - <<: *tile_defaults
+        id_field: nat_aqfr_cd
+        table: nat_aq
   principal_aq:
     type: collection
     title: USGS Principal Aquifers
@@ -312,6 +322,9 @@ resources:
         id_field: aq_code
         title_field: aq_name
         table: princi_aq
+      - <<: *tile_defaults
+        id_field: aq_code
+        table: princi_aq
   sec_hydrg_reg:
     type: collection
     title: USGS Secondary Hydrogeologic Regions
@@ -340,8 +353,9 @@ resources:
     providers:
       - <<: *provider_defaults
         name: PostgreSQL
-        id_field: id
         title_field: shr
+        table: sec_hydrg_reg
+      - <<: *tile_defaults
         table: sec_hydrg_reg
   gages: # updated 2024-06-12
     type: collection
@@ -424,7 +438,7 @@ resources:
                 ) AS ?datasets
               )
       - <<: *tile_defaults
-        data: ${TILES_PATH}/mainstems/${TILES_SUFFIX:-}
+        table: mainstems
   dams: # updated 2024-04-23
     type: collection
     title: Reference Dams
@@ -451,6 +465,8 @@ resources:
       - <<: *provider_defaults
         name: PostgreSQL
         title_field: description
+        table: ref_dams
+      - <<: *tile_defaults
         table: ref_dams
   pws: #updated 2024-07-02
     type: collection
@@ -494,7 +510,8 @@ resources:
         title_field: pws_name
         table: ref_pws
       - <<: *tile_defaults
-        data: ${TILES_PATH}/pws/${TILES_SUFFIX:-}
+        id_field: pwsid
+        table: ref_pws
   states:
     type: collection
     title: States
@@ -520,6 +537,9 @@ resources:
     providers:
       - <<: *provider_defaults
         name: PostgreSQL
+        id_field: geoid
+        table: states
+      - <<: *tile_defaults
         id_field: geoid
         table: states
   counties:
@@ -551,7 +571,8 @@ resources:
         id_field: geoid
         table: counties
       - <<: *tile_defaults
-        data: ${TILES_PATH}/counties/${TILES_SUFFIX:-}
+        id_field: geoid
+        table: counties
   aiannh:
     type: collection
     title: American Indian/Alaska Native Areas/Hawaiian Home Lands (AIANNH)
@@ -574,6 +595,9 @@ resources:
         name: PostgreSQL
         id_field: geoid
         table: aiannh
+      - <<: *tile_defaults
+        id_field: geoid
+        table: aiannh
   cbsa:
     type: collection
     title: Core-based statistical areas (CBSA)
@@ -594,6 +618,9 @@ resources:
     providers:
       - <<: *provider_defaults
         name: PostgreSQL
+        id_field: geoid
+        table: cbsa
+      - <<: *tile_defaults
         id_field: geoid
         table: cbsa
   ua10:
@@ -620,6 +647,9 @@ resources:
         id_field: geoid10
         title_field: name10
         table: ua10
+      - <<: *tile_defaults
+        id_field: geoid10
+        table: ua10
   places:
     type: collection
     title: Places
@@ -645,6 +675,9 @@ resources:
     providers:
       - <<: *provider_defaults
         name: PostgreSQL
+        id_field: geoid
+        table: places
+      - <<: *tile_defaults
         id_field: geoid
         table: places
   intersector:


### PR DESCRIPTION
This PR switches from using pre-generated vector tiles to generating them on the fly with MVT-postgresql provider. There are some performance issues at low zoom for large collections because the provider does not drop any features, but I expect them to not be noticeable behind the CDN.