### PR TITLE
some ref gage templating improvements

### DIFF
--- a/pygeoapi-skin-dashboard/templates/jsonld/gages/collections/items/item.jsonld
+++ b/pygeoapi-skin-dashboard/templates/jsonld/gages/collections/items/item.jsonld
@@ -33,7 +33,6 @@
 			"name": "{{ data.description | safe }}",
 			"url": "{{ data.subjectof | safe }}",
 			"provider": {
-				"@id": "provider",
 				"@type": "GovernmentOrganization",
 				"name": "USGS",
 				"url": "{{data.provider}}"
@@ -52,7 +51,7 @@
 				"@type": "GovernmentOrganization",
 				"name": "USGS",
 				"url": "{{data.provider}}"
-			},
+			}
 		}
 		{% endif %}
 	],

--- a/pygeoapi-skin-dashboard/templates/jsonld/gages/collections/items/item.jsonld
+++ b/pygeoapi-skin-dashboard/templates/jsonld/gages/collections/items/item.jsonld
@@ -1,29 +1,23 @@
 {
-	"@context": [
-		{
-			"schema": "https://schema.org/",
-			"skos": "http://www.w3.org/2004/02/skos/core#",
-			"hyf": "https://www.opengis.net/def/schema/hy_features/hyf/",
-			"gsp": "http://www.opengis.net/ont/geosparql#",
-			"name": "schema:name",
-			"sameAs": "schema:sameAs",
-			"subjectOf": {
-                            "@id": "schema:subjectOf",
-                            "@type": "@id"
-                        },
-			"provider": {
-				"@id": "schema:provider",
-				"@type": "@id"
-			},
-			"related": "skos:related",
-			"description": "schema:description",
-			"geo": "schema:geo",
-			"image": {
-				"@id": "schema:image",
-				"@type": "@id"
-			}
-		}
-	],
+	"@context": {
+		"@vocab": "https://schema.org/",
+		"xsd": "https://www.w3.org/TR/xmlschema-2/#",
+		"rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+		"dc": "http://purl.org/dc/terms/",
+		"dcat": "https://www.w3.org/ns/dcat#",
+		"freq": "http://purl.org/cld/freq/",
+		"qudt": "http://qudt.org/schema/qudt/",
+		"qudt-units": "http://qudt.org/vocab/unit/",
+		"qudt-quantkinds": "http://qudt.org/vocab/quantitykind/",
+		"gsp": "http://www.opengis.net/ont/geosparql#",
+		"locType": "http://vocabulary.odm2.org/sitetype",
+		"odm2var": "http://vocabulary.odm2.org/variablename/",
+		"odm2varType": "http://vocabulary.odm2.org/variabletype/",
+		"hyf": "https://www.opengis.net/def/schema/hy_features/hyf/",
+		"skos": "https://www.opengis.net/def/schema/hy_features/hyf/HY_HydroLocationType",
+		"ssn": "http://www.w3.org/ns/ssn/",
+		"ssn-system": "http://www.w3.org/ns/ssn/systems/"
+	},
 	"@id": "{{ data["@id"] }}",
 	"@type": [
 		"https://www.opengis.net/def/schema/hy_features/hyf/HY_HydrometricFeature",
@@ -31,11 +25,39 @@
 	],
     "name": "{{ data.name | safe  }}",
     "description": "{{ data.description | safe }}",
-{% if data.subjectOf %}  
-    "subjectOf": {
-	    "schema:url": "{{ data.subjectOf }}"
-    },
-{% endif %} 
+	{% if (data.subjectof or data.nws_url) %}
+	"subjectOf": [
+		{% if data.subjectof %}
+		{
+			"@type": "Dataset",
+			"name": "{{ data.description | safe }}",
+			"url": "{{ data.subjectof | safe }}",
+			"provider": {
+				"@id": "provider",
+				"@type": "GovernmentOrganization",
+				"name": "USGS",
+				"url": "{{data.provider}}"
+			}
+		}
+		{% endif %}
+		{% if data.subjectof and data.nws_url %}
+		,
+		{% endif %}
+		{% if data.nws_url %}
+		{
+			"@type": "Dataset",
+			"url": "{{ data.nws_url | safe }}",
+			"provider": {
+				"@id": "provider",
+				"@type": "GovernmentOrganization",
+				"name": "USGS",
+				"url": "{{data.provider}}"
+			},
+		}
+		{% endif %}
+	],
+	{% endif %}
+	
 {% if data.provider %}
     "provider": "{{ data.provider }}",
 {% endif %} 

--- a/pygeoapi-skin-dashboard/templates/jsonld/gages/collections/items/item.jsonld
+++ b/pygeoapi-skin-dashboard/templates/jsonld/gages/collections/items/item.jsonld
@@ -1,22 +1,8 @@
 {
 	"@context": {
 		"@vocab": "https://schema.org/",
-		"xsd": "https://www.w3.org/TR/xmlschema-2/#",
-		"rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-		"dc": "http://purl.org/dc/terms/",
-		"dcat": "https://www.w3.org/ns/dcat#",
-		"freq": "http://purl.org/cld/freq/",
-		"qudt": "http://qudt.org/schema/qudt/",
-		"qudt-units": "http://qudt.org/vocab/unit/",
-		"qudt-quantkinds": "http://qudt.org/vocab/quantitykind/",
 		"gsp": "http://www.opengis.net/ont/geosparql#",
-		"locType": "http://vocabulary.odm2.org/sitetype",
-		"odm2var": "http://vocabulary.odm2.org/variablename/",
-		"odm2varType": "http://vocabulary.odm2.org/variabletype/",
-		"hyf": "https://www.opengis.net/def/schema/hy_features/hyf/",
-		"skos": "https://www.opengis.net/def/schema/hy_features/hyf/HY_HydroLocationType",
-		"ssn": "http://www.w3.org/ns/ssn/",
-		"ssn-system": "http://www.w3.org/ns/ssn/systems/"
+		"hyf": "https://www.opengis.net/def/schema/hy_features/hyf/"
 	},
 	"@id": "{{ data["@id"] }}",
 	"@type": [
@@ -47,7 +33,6 @@
 			"@type": "Dataset",
 			"url": "{{ data.nws_url | safe }}",
 			"provider": {
-				"@id": "provider",
 				"@type": "GovernmentOrganization",
 				"name": "USGS",
 				"url": "{{data.provider}}"


### PR DESCRIPTION
Makes ref gages more similar to the format of wqp; need to align with kyle on specifics of any hard coded values he wants

the jsonld output below uses the same context as wqp and in the jsonld palyground gets canonicalized without issues

i did not include the `variableMeasured` info like we have in wqp https://sta.geoconnex.dev/collections/WQP/Things/items/'0800257-CC-02'?f=jsonld here since it doesnt seem the ref gages have this unit info

```json
{
  "@context": {
    "@vocab": "https://schema.org/",
    "xsd": "https://www.w3.org/TR/xmlschema-2/#",
    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
    "dc": "http://purl.org/dc/terms/",
    "dcat": "https://www.w3.org/ns/dcat#",
    "freq": "http://purl.org/cld/freq/",
    "qudt": "http://qudt.org/schema/qudt/",
    "qudt-units": "http://qudt.org/vocab/unit/",
    "qudt-quantkinds": "http://qudt.org/vocab/quantitykind/",
    "gsp": "http://www.opengis.net/ont/geosparql#",
    "locType": "http://vocabulary.odm2.org/sitetype",
    "odm2var": "http://vocabulary.odm2.org/variablename/",
    "odm2varType": "http://vocabulary.odm2.org/variabletype/",
    "hyf": "https://www.opengis.net/def/schema/hy_features/hyf/",
    "skos": "https://www.opengis.net/def/schema/hy_features/hyf/HY_HydroLocationType",
    "ssn": "http://www.w3.org/ns/ssn/",
    "ssn-system": "http://www.w3.org/ns/ssn/systems/"
  },
  "@id": "https://geoconnex.us/ref/gages/1000001",
  "@type": [
    "https://www.opengis.net/def/schema/hy_features/hyf/HY_HydrometricFeature",
    "https://www.opengis.net/def/schema/hy_features/hyf/HY_HydroLocation"
  ],
  "name": "PENISTAJA TRIB UNTREATED NEAR TORREON, NM",
  "description": "USGS NWIS Stream/River/Lake Site 08332622: PENISTAJA TRIB UNTREATED NEAR TORREON, NM",
  "subjectOf": [
    {
      "@type": "Dataset",
      "name": "USGS NWIS Stream/River/Lake Site 08332622: PENISTAJA TRIB UNTREATED NEAR TORREON, NM",
      "url": "https://waterdata.usgs.gov/monitoring-location/08332622",
      "provider": {
        "@type": "GovernmentOrganization",
        "name": "USGS",
        "url": "https://waterdata.usgs.gov"
      }
    }
  ],
  "provider": "https://waterdata.usgs.gov",
  "hyf:referencedPosition": [
    {
      "hyf:HY_IndirectPosition": {
        "hyf:distanceExpression": {
          "hyf:HY_DistanceFromReferent": {
            "hyf:interpolative": 80.3326
          }
        },
        "hyf:distanceDescription": {
          "hyf:HY_DistanceDescription": "upstream"
        },
        "hyf:linearElement": {
          "@id": "https://geoconnex.us/nhdplusv2/reachcode/13020205000216"
        }
      }
    },
    {
      "hyf:HY_IndirectPosition": {
        "hyf:linearElement": {
          "@id": "https://geoconnex.us/ref/mainstems/1622734"
        }
      }
    }
  ],
  "hyf:HY_HydroLocationType": "hydrometricStation",
  "geo": {
    "@type": "schema:GeoCoordinates",
    "schema:longitude": -107.2826306,
    "schema:latitude": 35.9456833
  },
  "gsp:hasGeometry": {
    "@type": "http://www.opengis.net/ont/sf#Point",
    "gsp:asWKT": {
      "@type": "http://www.opengis.net/ont/geosparql#wktLiteral",
      "@value": "POINT (-107.2826306 35.9456833)"
    }
  }
}
```