### PR TITLE
Remove schema geo from huc12

### DIFF
--- a/pygeoapi-skin-dashboard/templates/jsonld/hu12/collections/items/item.jsonld
+++ b/pygeoapi-skin-dashboard/templates/jsonld/hu12/collections/items/item.jsonld
@@ -35,6 +35,5 @@
     {% endfor %}
     ],
     {% endif %}
-    "gsp:hasGeometry": {{ data['gsp:hasGeometry'] | to_json }},
-    "geo": {{ data['schema:geo'] | to_json | safe }}
+    "gsp:hasGeometry": {{ data['gsp:hasGeometry'] | to_json }}
 }


### PR DESCRIPTION
The huc12 layer has features in excess of 200mb due to complex geometry. In order to serve this as JSON-LD we cannot serve both WKT and schema:geo representations of the geometry